### PR TITLE
Fix URLs in module.json for manifest and download links

### DIFF
--- a/module.json
+++ b/module.json
@@ -36,8 +36,8 @@
   },
   "socket": true,
   "url": "https://github.com/Fuhrizen/pf2e-kingmaker-map-enhancements",
-  "manifest": "https://github.com/Fuhrizen/pf2e-map-enhancements/releases/latest/download/module.json",
-  "download": "https://github.com/Fuhrizen/pf2e-map-enhancements/releases/latest/download/module.zip",
+  "manifest": "https://github.com/Fuhrizen/pf2e-kingmaker-map-enhancements/releases/latest/download/module.json",
+  "download": "https://github.com/Fuhrizen/pf2e-kingmaker-map-enhancements/releases/latest/download/module.zip",
   "relationships": {
     "systems": [
       {


### PR DESCRIPTION
Update the URLs in module.json to point to the correct manifest and download links for the project.